### PR TITLE
retailer id should not be hardcoded as they will get autogenerated on…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ coverage.xml
 
 # PyBuilder
 target/
+
+# Local environment
+.env.local

--- a/server/tests/test_users_service.py
+++ b/server/tests/test_users_service.py
@@ -37,8 +37,11 @@ class CreateUserTestCase(unittest.TestCase):
         demo = create_demo()
         demo_guid = loads(demo).get('guid')
 
-        # Create new user
-        user = user_service.create_user(demo_guid, 'R1')
+        # Retrieve retailers
+        retailers_json = loads(demo_service.get_demo_retailers(demo_guid))
+
+        # Create new user assigned to the first retailer
+        user = user_service.create_user(demo_guid, retailers_json[0].get('id'))
         user_json = loads(user)
 
         # TODO: Update to use assertIsInstance(a,b)
@@ -58,10 +61,15 @@ class CreateUserTestCase(unittest.TestCase):
         demo = create_demo()
         demo_guid = loads(demo).get('guid')
 
+        # Retrieve retailers
+        retailers_json = loads(demo_service.get_demo_retailers(demo_guid))
+
         # Attempt to create user with invalid inputs
+        # Invalid demo guid
         self.assertRaises(ResourceDoesNotExistException,
                           user_service.create_user,
-                          'ABC123', 'R1')
+                          'ABC123', retailers_json[0].get('id'))
+        # Invalid retailer id
         self.assertRaises(ResourceDoesNotExistException,
                           user_service.create_user,
                           demo_guid, 'R99999')


### PR DESCRIPTION
@JakePeyser 

with the changes made in https://github.com/IBM-Bluemix/logistics-wizard-erp/issues/3 the retailer ID will be different for each demo environment. The "R1" will become something like "R1-<demoId>".

Thus test_users_service.py was failing with the new code I have in the ERP service branch. I changed the test so that it just picks the first retailer available. This new code works even with the current deployed ERP service that does not yet isolated data per demo env.