### PR TITLE
Login to demo session from url

### DIFF
--- a/client-src/src/modules/demos.js
+++ b/client-src/src/modules/demos.js
@@ -1,17 +1,17 @@
-// NOTE: This will need to be hooked up to 'store/reducers' and 'store/sagas'
+import { call, take, put, select } from 'redux-saga/effects';
+import api from 'services';
 
-// import { call, take, put, select } from 'redux-saga/effects';
 // ------------------------------------
 // Constants
 // ------------------------------------
-export const CREATE_DEMO_SUCCESS = 'demos/CREATE_DEMO_SUCCESS';
+export const RECEIVE_DEMO_SUCCESS = 'demos/RECEIVE_DEMO_SUCCESS';
 export const LOGIN_SUCCESS = 'demos/LOGIN_SUCCESS';
 
 // ------------------------------------
 // Actions
 // ------------------------------------
-export const createDemoSuccess = (value) => ({
-  type: CREATE_DEMO_SUCCESS,
+export const receiveDemoSuccess = (value) => ({
+  type: RECEIVE_DEMO_SUCCESS,
   payload: value,
 });
 
@@ -21,7 +21,7 @@ export const loginSuccess = (value) => ({
 });
 
 export const actions = {
-  createDemoSuccess,
+  receiveDemoSuccess,
   loginSuccess,
 };
 
@@ -29,7 +29,7 @@ export const actions = {
 // Action Handlers
 // ------------------------------------
 const ACTION_HANDLERS = {
-  [CREATE_DEMO_SUCCESS]: (state, action) => ({
+  [RECEIVE_DEMO_SUCCESS]: (state, action) => ({
     ...state,
     name: action.payload.name,
     guid: action.payload.guid,
@@ -41,7 +41,7 @@ const ACTION_HANDLERS = {
   }),
   [LOGIN_SUCCESS]: (state, action) => ({
     ...state,
-    token: action.payload.token,
+    token: action.payload,
   }),
 };
 

--- a/client-src/src/modules/demos.js
+++ b/client-src/src/modules/demos.js
@@ -1,6 +1,3 @@
-import { call, take, put, select } from 'redux-saga/effects';
-import api from 'services';
-
 // ------------------------------------
 // Constants
 // ------------------------------------

--- a/client-src/src/routes/CreateDemo/modules/CreateDemo.js
+++ b/client-src/src/routes/CreateDemo/modules/CreateDemo.js
@@ -2,7 +2,7 @@ import { call, take, put, select } from 'redux-saga/effects';
 import { push } from 'react-router-redux';
 import api from 'services';
 
-import { loginSuccess, createDemoSuccess, demoSelector } from 'modules/demos';
+import { loginSuccess, receiveDemoSession, demoSelector } from 'modules/demos';
 import { adminDataReceived } from 'routes/Dashboard/modules/Dashboard';
 
 // ------------------------------------
@@ -49,9 +49,9 @@ export function *watchCreateDemo() {
     const { payload } = yield take(CREATE_DEMO);
     try {
       const demoSession = yield call(api.createDemo, payload.name, payload.email);
-      yield put(push('/dashboard'));
-      yield put(createDemoSuccess(demoSession));
+      yield put(receiveDemoSession(demoSession));
       const demoState = yield select(demoSelector);
+      yield put(push(`/dashboard/${demoState.guid}`));
       const token = yield call(api.login, demoState.id, demoState.guid);
       yield put(loginSuccess(token));
       const adminData = yield call(api.getAdminData, token.token);

--- a/client-src/src/routes/CreateDemo/modules/CreateDemo.js
+++ b/client-src/src/routes/CreateDemo/modules/CreateDemo.js
@@ -2,7 +2,7 @@ import { call, take, put, select } from 'redux-saga/effects';
 import { push } from 'react-router-redux';
 import api from 'services';
 
-import { loginSuccess, receiveDemoSession, demoSelector } from 'modules/demos';
+import { loginSuccess, receiveDemoSuccess, demoSelector } from 'modules/demos';
 import { adminDataReceived } from 'routes/Dashboard/modules/Dashboard';
 
 // ------------------------------------
@@ -47,19 +47,18 @@ export const createDemoSelector = state => state.createDemo;
 export function *watchCreateDemo() {
   while (true) {
     const { payload } = yield take(CREATE_DEMO);
+
     try {
       const demoSession = yield call(api.createDemo, payload.name, payload.email);
-      yield put(receiveDemoSession(demoSession));
-      const demoState = yield select(demoSelector);
-      yield put(push(`/dashboard/${demoState.guid}`));
-      const token = yield call(api.login, demoState.id, demoState.guid);
-      yield put(loginSuccess(token));
-      const adminData = yield call(api.getAdminData, token.token);
-      yield put(adminDataReceived(adminData));
+      yield put(receiveDemoSuccess(demoSession));
     }
     catch (error) {
       console.log(error);
+      // yield put(createDemoFailure(error));
     }
+
+    const demoState = yield select(demoSelector);
+    yield put(push(`/dashboard/${demoState.guid}`));
   }
 }
 

--- a/client-src/src/routes/Dashboard/components/Dashboard.jsx
+++ b/client-src/src/routes/Dashboard/components/Dashboard.jsx
@@ -1,15 +1,27 @@
 import React from 'react';
 import classes from './Dashboard.scss';
 
-export const Dashboard = (props) => (
-  <div className={classes.dashboard}>
-    <h4>Dashboard - Yay, you created a demo!</h4>
-    <p>Demo Name: {props.demoName}</p>
-  </div>
-);
+export default class Dashboard extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    props.getAdminData(props.params.guid);
+  }
+
+  render() {
+    return (
+      <div className={classes.dashboard}>
+        <h4>Dashboard - Yay, you created a demo!</h4>
+        <p>Demo Name: {this.props.demoName || 'loading...'}</p>
+        <pre>{this.props.dbdata ? JSON.stringify(this.props.dbdata, null, 2) : 'loading...'}</pre>
+      </div>
+    );
+  }
+}
+
 
 Dashboard.propTypes = {
   demoName: React.PropTypes.string.isRequired,
+  dbdata: React.PropTypes.object.isRequired,
+  getAdminData: React.PropTypes.func.isRequired,
+  params: React.PropTypes.object.isRequired,
 };
-
-export default Dashboard;

--- a/client-src/src/routes/Dashboard/components/Dashboard.test.js
+++ b/client-src/src/routes/Dashboard/components/Dashboard.test.js
@@ -1,15 +1,21 @@
 import test from 'ava';
 import React from 'react';
+import sinon from 'sinon';
 import { bindActionCreators } from 'redux';
 import { shallow } from 'enzyme';
-import { Dashboard } from './Dashboard';
+import Dashboard from './Dashboard';
 
 const setup = () => {
   const spies = {
+    getAdminData: sinon.spy(),
+    dispatch: sinon.spy(),
   };
   const props = {
     demoName: 'Test Demo',
+    dbdata: { fakeData: 'fake stuff' },
+    params: { guid: '1234' },
     ...bindActionCreators({
+      getAdminData: spies.getAdminData,
     }, spies.dispatch),
   };
   const component = shallow(<Dashboard {...props} />);
@@ -19,8 +25,18 @@ const setup = () => {
 
 test.todo('write tests for dashboard elements once complete.');
 test('(Component) Renders with expected elements', t => {
-  const { component } = setup();
+  const { props, component } = setup();
 
   t.true(component.is('div'),
     'is wrapped by a div');
+  t.regex(component.find('p').first().text(), new RegExp(props.demoName, 'g'),
+    'renders demo name from props');
+});
+
+test('(Component) Works as expected.', t => {
+  const { spies } = setup();
+
+  t.true(spies.getAdminData.calledOnce,
+    'getAdminData is called on creation');
+  t.true(spies.dispatch.calledOnce);
 });

--- a/client-src/src/routes/Dashboard/containers/DashboardContainer.js
+++ b/client-src/src/routes/Dashboard/containers/DashboardContainer.js
@@ -1,12 +1,14 @@
 import { connect } from 'react-redux';
-// import { getQuote } from '../modules/Dashboard';
+import { getAdminData } from '../modules/Dashboard';
 import Dashboard from '../components/Dashboard';
 
 const mapActionCreators = {
+  getAdminData,
 };
 
 const mapStateToProps = (state) => ({
   demoName: state.demoSession.name,
+  dbdata: state.dashboard,
 });
 
 export default connect(mapStateToProps, mapActionCreators)(Dashboard);

--- a/client-src/src/routes/Dashboard/index.js
+++ b/client-src/src/routes/Dashboard/index.js
@@ -2,7 +2,7 @@ import { injectReducer } from 'store/reducers';
 import { injectSagas } from 'store/sagas';
 
 export default (store) => ({
-  path: 'dashboard',
+  path: 'dashboard/:guid',
   getComponent(nextState, cb) {
     require.ensure([], (require) => {
       const Dashboard = require('./containers/DashboardContainer').default;

--- a/client-src/src/routes/Dashboard/index.test.js
+++ b/client-src/src/routes/Dashboard/index.test.js
@@ -5,6 +5,6 @@ test('(Route) should return a route config object', t => {
   t.is(typeof (DashboardRoute({})), 'object');
 });
 
-test('(Route) Config should contain path "dashboard"', t => {
-  t.is(DashboardRoute({}).path, 'dashboard');
+test('(Route) Config should contain path "dashboard/:guid"', t => {
+  t.is(DashboardRoute({}).path, 'dashboard/:guid');
 });

--- a/client-src/src/routes/Dashboard/modules/Dashboard.js
+++ b/client-src/src/routes/Dashboard/modules/Dashboard.js
@@ -70,25 +70,25 @@ function *watchGetAdminData() {
         console.log(error);
         // yield put(receiveDemoFailure(error));
       }
+    }
 
-      try {
-        const { token } = yield call(api.login, demoState.id, demoState.guid);
-        yield put(loginSuccess(token));
-        demoState = yield select(demoSelector);
-      }
-      catch (error) {
-        console.log(error);
-        // yield put(loginFailure(error));
-      }
+    try {
+      const { token } = yield call(api.login, demoState.id, demoState.guid);
+      yield put(loginSuccess(token));
+      demoState = yield select(demoSelector);
+    }
+    catch (error) {
+      console.log(error);
+      // yield put(loginFailure(error));
+    }
 
-      try {
-        const adminData = yield call(api.getAdminData, demoState.token);
-        yield put(adminDataReceived(adminData));
-      }
-      catch (error) {
-        console.log(error);
-        // yield put(getAdminDataFilure(error));
-      }
+    try {
+      const adminData = yield call(api.getAdminData, demoState.token);
+      yield put(adminDataReceived(adminData));
+    }
+    catch (error) {
+      console.log(error);
+      // yield put(getAdminDataFilure(error));
     }
   }
 }

--- a/client-src/src/routes/Dashboard/modules/Dashboard.js
+++ b/client-src/src/routes/Dashboard/modules/Dashboard.js
@@ -1,20 +1,29 @@
 // import { delay } from 'redux-saga';
-// import { call, take, put, select } from 'redux-saga/effects';
+import { call, take, put, select } from 'redux-saga/effects';
+import api from 'services';
+import { loginSuccess, receiveDemoSuccess, demoSelector } from 'modules/demos';
 
 // ------------------------------------
 // Constants
 // ------------------------------------
+export const GET_ADMIN_DATA = 'Dashboard/GET_ADMIN_DATA';
 export const ADMIN_DATA_RECEIVED = 'Dashboard/ADMIN_DATA_RECEIVED';
 
 // ------------------------------------
 // Actions
 // ------------------------------------
+export const getAdminData = (value) => ({
+  type: GET_ADMIN_DATA,
+  payload: value,
+});
+
 export const adminDataReceived = (value) => ({
   type: ADMIN_DATA_RECEIVED,
   payload: value,
 });
 
 export const actions = {
+  getAdminData,
   adminDataReceived,
 };
 
@@ -47,5 +56,43 @@ export default dashboardReducer;
 // This is set up in `../index.js` as the key in  `injectSagas(store, { key: 'dashboard', sagas });`
 export const dashboardSelector = state => state.dashboard;
 
+function *watchGetAdminData() {
+  while (true) {
+    const { payload } = yield take(GET_ADMIN_DATA);
+    let demoState = yield select(demoSelector);
+    if (demoState.guid !== payload) {
+      try {
+        const demoSession = yield call(api.getDemo, payload);
+        yield put(receiveDemoSuccess(demoSession));
+        demoState = yield select(demoSelector);
+      }
+      catch (error) {
+        console.log(error);
+        // yield put(receiveDemoFailure(error));
+      }
+
+      try {
+        const { token } = yield call(api.login, demoState.id, demoState.guid);
+        yield put(loginSuccess(token));
+        demoState = yield select(demoSelector);
+      }
+      catch (error) {
+        console.log(error);
+        // yield put(loginFailure(error));
+      }
+
+      try {
+        const adminData = yield call(api.getAdminData, demoState.token);
+        yield put(adminDataReceived(adminData));
+      }
+      catch (error) {
+        console.log(error);
+        // yield put(getAdminDataFilure(error));
+      }
+    }
+  }
+}
+
 export const sagas = [
+  watchGetAdminData,
 ];

--- a/client-src/src/services/index.js
+++ b/client-src/src/services/index.js
@@ -19,16 +19,21 @@ export const createDemo = (name, email) =>
     method: 'POST',
     body: { name, email },
   });
+
+export const getDemo = (guid) => callApi(`demos/${guid}`);
+
 export const login = (id, guid) =>
   callApi(`demos/${guid}/login`, {
     method: 'POST',
     body: { userId: id },
   });
+
 export const getAdminData = token =>
   callApi('admin', { headers: { Authorization: `Bearer ${token}` } });
 
 export const api = {
   createDemo,
+  getDemo,
   login,
   getAdminData,
 };


### PR DESCRIPTION
 - Create demo reducer now only handles creating demo and changing route to dashboard
 - Once dashboard component is created, it's constructor will handle checking the params from the URL vs the guid held in state, if no guid is present it will grab the session from api, and then login and retrieve the admin data.

**Further TODO:**
 - Write error handling for various api calls breaking or edge cases
 - Finish writing tests
 - Store guid of last logged in demo into local storage / cookie so we can auto-login users when they return, without them having to bookmark the url or check e-mail etc.

**Login flow from create demo:**
![screen recording 2016-08-24 at 07 45 am](https://cloud.githubusercontent.com/assets/8884298/17931393/de0f4258-69d0-11e6-8910-4ca5f03b1cd4.gif)

**Login flow from a saved url:**
![screen recording 2016-08-24 at 07 48 am](https://cloud.githubusercontent.com/assets/8884298/17931408/f28c42b2-69d0-11e6-8567-2d2202475610.gif)

closes #57 
